### PR TITLE
refactor: fork 를 위해 스레드 구조체에  parent_if를 선언해서 if 를 전달하던 것을 인자전달로 개선

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -170,7 +170,6 @@ struct thread {
 	struct file *running;
 	
 	// project 2: fork
-	struct intr_frame parent_if;
 	struct semaphore fork_sema;
 
 

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -115,7 +115,7 @@ tid_t process_fork(const char *name, struct intr_frame *if_ UNUSED) {
 
     struct thread *curr = thread_current();
 
-    tid_t tid = thread_create(name, PRI_DEFAULT, __do_fork, curr);
+    tid_t tid = thread_create(name, PRI_DEFAULT, __do_fork, if_);
     if(tid == TID_ERROR)
         return TID_ERROR;
 
@@ -188,11 +188,11 @@ static bool duplicate_pte(uint64_t *pte, void *va, void *aux) {
  *       this function. */
 static void __do_fork(void *aux) {
     struct intr_frame if_;
-    struct thread *parent = (struct thread *)aux;
+    struct thread *parent = (struct thread *) pg_round_down(aux);
     struct thread *current = thread_current();
     /* TODO: 부모 if_를 어떻게 전달할 지 고민합니다. (즉, process_fork()의 if_를) */
     /* TODO: somehow pass the parent_if. (i.e. process_fork()'s if_) */
-    struct intr_frame *parent_if = &parent -> parent_if;
+    struct intr_frame *parent_if = (struct intr_frame *) aux;
     bool succ = true;
 
     /* 1. CPU 컨텍스트를 로컬 스택으로 읽어옵니다. */

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -79,12 +79,9 @@ syscall_init (void) {
     lock_init(&filesys_lock);
 }
 
-
 /* 주요 시스템 호출 인터페이스 */
 /* The main system call interface */
 void syscall_handler(struct intr_frame *f UNUSED) {
-    // todo: 구현을 여기에 하세요
-    // TODO: Your implementation goes here.
 
     int sys_num = f->R.rax;
 
@@ -99,7 +96,6 @@ void syscall_handler(struct intr_frame *f UNUSED) {
             exit(f->R.rdi);
             break;
         case SYS_FORK:
-            memcpy(&thread_current()->parent_if, f, sizeof(struct intr_frame)); // 현재 thread의 parent_if에 if_를 저장
             f->R.rax = fork(f->R.rdi);
             break;
         case SYS_EXEC:
@@ -339,8 +335,8 @@ void close (int fd) {
 
 pid_t fork (const char *thread_name) {
     check_address(thread_name);
-    struct thread *t = thread_current();
-    return process_fork(thread_name, &t->parent_if);
+    struct intr_frame *if_ = pg_round_up(&thread_name) - sizeof(struct intr_frame);
+    return process_fork(thread_name, if_);
 }
 
 int wait (pid_t pid)


### PR DESCRIPTION
thread 구조체에 불필요한 parent_if 제거

fork 함수 내에서 R.rdi 값을 page up 한후 struct intr_frame 만큼 내려주어 f 포인터를 찾고 process_fork 인자로 넘겨줌